### PR TITLE
Retrieve src-netbsd over httpS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/rumpkernel/buildrump.sh.git
 [submodule "rumpsrc"]
 	path = src-netbsd
-	url = http://github.com/rumpkernel/src-netbsd
+	url = https://github.com/rumpkernel/src-netbsd.git


### PR DESCRIPTION
The src-netbsd repository has no PGP signatures but HTTPS is available.