### PR TITLE
Enable parameters expansion in the prompt

### DIFF
--- a/rumpctrl.sh.in
+++ b/rumpctrl.sh.in
@@ -6,6 +6,10 @@ rrCANDO=true
 #[ "${SHELL}" != "${SHELL%bash}" ] \
 #    || { echo "environment requires bash"; rrCANDO=false; }
 
+# enable parameters expansion in the prompt
+[ "${SHELL}" = "${SHELL%/zsh}" ] \
+    || set -o PROMPT_SUBST
+
 # sed replacement is not run with /g ...
 [ "XXXPATHXXX" = "XXXPATHXXX" ] && { echo "not preprocessed"; rrCANDO=false; }
 


### PR DESCRIPTION
For this to work on zsh a specific option must be enabled.